### PR TITLE
✨ feat(filter-group): add "unassigned" option for responsible filter …

### DIFF
--- a/front-end/src/components/Filtergroup.tsx
+++ b/front-end/src/components/Filtergroup.tsx
@@ -57,7 +57,6 @@ export const Filtergroup: React.FC<FiltergroupProps> = ({
     onPriorityChange(localPriority);
     onDueDateRangeChange(localFrom, localTo);
     onResponsibleChange(localResponsible);
-    setShowFilters(false);
   };
 
   const clearLocalAndParent = () => {
@@ -187,6 +186,7 @@ export const Filtergroup: React.FC<FiltergroupProps> = ({
                   style={{ width: "100%", padding: "8px", borderRadius: 6 }}
                 >
                   <option value="">Todos os responsáveis</option>
+                  <option value="unassigned">Sem responsável</option>
                   {members.map((m) => (
                     <option key={m.uuid} value={m.uuid}>
                       {m.name}


### PR DESCRIPTION
This pull request enhances the task filtering functionality by allowing users to filter tasks that have no responsible person assigned. It introduces the "unassigned" option in the responsible filter, updates the filter logic to support this new option, and improves the robustness of date and priority filtering.

**Responsible filter improvements:**

* Added the "Sem responsável" ("unassigned") option to the responsible dropdown in the `Filtergroup` component, enabling users to filter for tasks without an assigned responsible person.
* Updated the `TaskFilters` interface to allow `responsibleUuid` to be either a string or "unassigned".
* Modified the filtering logic in `useTaskFilters` to handle the "unassigned" case, returning only tasks without a responsible person when selected.

**Filtering logic robustness:**

* Improved the due date filter to correctly exclude tasks without a due date when date filters are applied.
* Refactored the priority and search filtering code for better readability and maintainability. [[1]](diffhunk://#diff-4e570e40de496008d0faa2f4e58c8fd779b7850c7b78e5287442e10ec8c435bcL31-R34) [[2]](diffhunk://#diff-4e570e40de496008d0faa2f4e58c8fd779b7850c7b78e5287442e10ec8c435bcL53-R79) [[3]](diffhunk://#diff-4e570e40de496008d0faa2f4e58c8fd779b7850c7b78e5287442e10ec8c435bcL104-R128)…and improve filtering logic