### PR TITLE
🐛 fix(mapper): add missing import for Responsible class in TaskMapper

### DIFF
--- a/back-end/api-3/src/main/java/com/api_3/api_3/mapper/TaskMapper.java
+++ b/back-end/api-3/src/main/java/com/api_3/api_3/mapper/TaskMapper.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 import com.api_3.api_3.dto.response.TaskResponse;
 import com.api_3.api_3.model.entity.Task;
-
+import com.api_3.api_3.model.entity.Responsible;
 
 @Component
 public class TaskMapper {


### PR DESCRIPTION
This pull request introduces a minor update to the `TaskMapper` class by importing the `Responsible` entity. No other changes are present.